### PR TITLE
Add GraphQL token pricing and UI improvements

### DIFF
--- a/android/apollo/client.ts
+++ b/android/apollo/client.ts
@@ -1,0 +1,169 @@
+import type {
+  FieldPolicy,
+  NormalizedCacheObject,
+  RequestHandler,
+} from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  createHttpLink,
+  from,
+  InMemoryCache,
+  Observable,
+} from "@apollo/client";
+import { RetryLink } from "@apollo/client/link/retry";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { AsyncStorageWrapper, persistCacheSync } from "apollo3-cache-persist";
+
+// Backpack GraphQL API URL
+const BACKPACK_GRAPHQL_API_URL = "https://backpack-api.xnfts.dev/v2/graphql";
+
+const SEMVER_RX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-.+)$/;
+
+type Connection = {
+  edges: Array<{ node: any }>;
+  pageInfo: {
+    hasNextPage: boolean;
+  };
+};
+
+/**
+ * Custom cache policy for transaction connections
+ * Handles pagination and deduplication
+ */
+export function customTransactionConnectionPolicy(): FieldPolicy {
+  const emptyConnection: Connection = {
+    edges: [],
+    pageInfo: {
+      hasNextPage: true,
+    },
+  };
+
+  return {
+    keyArgs: ["filters", ["token"]],
+    merge(
+      existing: Connection = emptyConnection,
+      incoming: Connection,
+      { args }
+    ): Connection {
+      const offset = args?.filters?.offset ?? 0;
+      if (offset === 0) {
+        return incoming;
+      }
+
+      const merged = existing.edges.slice(0, offset + 1);
+      const ids = new Set<string>();
+      for (const edge of incoming.edges) {
+        const id = edge.node.id ?? edge.node.__ref.split(":")[1];
+        if (!ids.has(id)) {
+          ids.add(id);
+          merged.push(edge);
+        }
+      }
+
+      return {
+        edges: merged,
+        pageInfo: incoming.pageInfo,
+      };
+    },
+  };
+}
+
+// Create cache instance with type policies
+const cache = new InMemoryCache({
+  typePolicies: {
+    Wallet: {
+      fields: {
+        transactions: customTransactionConnectionPolicy(),
+      },
+    },
+  },
+});
+
+/**
+ * Apollo Link handler that returns cached data on network errors
+ * Provides fallback to cached data when network is unavailable
+ */
+export const cacheOnErrorApolloLinkHandler: RequestHandler = (
+  operation,
+  forward
+) => {
+  if (!forward) return null;
+
+  return new Observable((observer) => {
+    const subscription = forward(operation).subscribe({
+      next: observer.next.bind(observer),
+      complete: observer.complete.bind(observer),
+      error: (networkError) => {
+        const cached = cache.readQuery<any>({
+          query: operation.query,
+          variables: operation.variables,
+        });
+
+        if (!cached) {
+          observer.next({ data: undefined, errors: [networkError] });
+        } else {
+          observer.next({ data: cached });
+        }
+        observer.complete();
+      },
+    });
+
+    return () => {
+      if (subscription) subscription.unsubscribe();
+    };
+  });
+};
+
+/**
+ * Creates and configures an Apollo Client instance for React Native
+ * @param {string} clientName - Name of the client (e.g., "backpack-android")
+ * @param {string} clientVersion - Version of the client
+ * @param {Record<string, string>} [headers] - Optional HTTP headers
+ * @returns {ApolloClient<NormalizedCacheObject>} Configured Apollo Client
+ */
+export function createApolloClient(
+  clientName: string,
+  clientVersion: string,
+  headers?: Record<string, string>
+): ApolloClient<NormalizedCacheObject> {
+  const httpLink = createHttpLink({
+    uri: BACKPACK_GRAPHQL_API_URL,
+    headers,
+  });
+
+  // Persist cache to AsyncStorage for React Native
+  try {
+    persistCacheSync({
+      cache,
+      storage: new AsyncStorageWrapper(AsyncStorage),
+    });
+  } catch (error) {
+    console.warn("Failed to persist Apollo cache:", error);
+  }
+
+  const version = SEMVER_RX.test(clientVersion)
+    ? clientVersion.split("-")[0]
+    : clientVersion;
+
+  return new ApolloClient({
+    name: clientName,
+    version,
+    cache,
+    link: from([
+      new ApolloLink(cacheOnErrorApolloLinkHandler),
+      new RetryLink({
+        delay: {
+          initial: 500,
+          max: Infinity,
+          jitter: true,
+        },
+        attempts: {
+          max: 10,
+          retryIf: (error, _operation) => !!error,
+        },
+      }),
+      httpLink,
+    ]),
+  });
+}

--- a/android/apollo/gql.ts
+++ b/android/apollo/gql.ts
@@ -1,0 +1,18 @@
+import { DocumentNode } from "@apollo/client";
+import { TypedDocumentNode as DocumentTypeDecoration } from "@graphql-typed-document-node/core";
+import { parse } from "graphql";
+
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by Apollo Client.
+ * This is a simplified version for React Native compatibility.
+ */
+export type TypedDocumentString<TResult, TVariables> = string & {
+  __apiType?: DocumentTypeDecoration<TResult, TVariables>;
+};
+
+export function gql(source: TemplateStringsArray): DocumentNode;
+export function gql(source: string): DocumentNode;
+export function gql(source: string | TemplateStringsArray): DocumentNode {
+  const doc = Array.isArray(source) ? source[0] : source;
+  return parse(doc);
+}

--- a/android/apollo/queries.ts
+++ b/android/apollo/queries.ts
@@ -1,0 +1,63 @@
+import { gql } from "./gql";
+
+/**
+ * GraphQL query to fetch token balances for a wallet
+ *
+ * Returns:
+ * - Aggregate portfolio value and 24h change
+ * - Individual token balances with market data
+ * - Token metadata (logo, name, symbol)
+ *
+ * @example
+ * ```typescript
+ * const { data } = useQuery(GET_TOKEN_BALANCES_QUERY, {
+ *   variables: {
+ *     address: "YOUR_WALLET_ADDRESS",
+ *     providerId: "SOLANA"
+ *   }
+ * });
+ * ```
+ */
+export const GET_TOKEN_BALANCES_QUERY = gql(`
+  query GetTokenBalances($address: String!, $providerId: ProviderID!) {
+    wallet(address: $address, providerId: $providerId) {
+      id
+      balances {
+        id
+        aggregate {
+          id
+          percentChange
+          value
+          valueChange
+        }
+        tokens {
+          edges {
+            node {
+              id
+              address
+              amount
+              decimals
+              displayAmount
+              marketData {
+                id
+                percentChange
+                price
+                value
+                valueChange
+              }
+              token
+              tokenListEntry {
+                id
+                address
+                decimals
+                logo
+                name
+                symbol
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`);

--- a/android/apollo/types.ts
+++ b/android/apollo/types.ts
@@ -1,0 +1,134 @@
+// GraphQL Types for Backpack API
+// Based on official Backpack GraphQL schema
+
+/**
+ * Provider ID for blockchain networks
+ * For Solana, use "SOLANA" (without network suffix)
+ * Backpack GraphQL API: https://backpack-api.xnfts.dev/v2/graphql
+ */
+export type ProviderId =
+  | "SOLANA"           // Solana (all networks: mainnet/devnet/testnet)
+  | "SOLANA-mainnet"   // Type-only for compatibility, use "SOLANA" for API calls
+  | "SOLANA-devnet"    // Type-only for compatibility, use "SOLANA" for API calls
+  | "SOLANA-testnet";  // Type-only for compatibility, use "SOLANA" for API calls
+
+/**
+ * Query variables for GetTokenBalances query
+ */
+export type GetTokenBalancesQueryVariables = {
+  address: string;
+  providerId: ProviderId;
+};
+
+/**
+ * Token metadata from the token list
+ * Contains display information like logo, name, symbol
+ */
+export type TokenListEntry = {
+  __typename?: "TokenListEntry";
+  id: string;
+  address: string;
+  decimals: number;
+  logo?: string | null;
+  name: string;
+  symbol: string;
+};
+
+/**
+ * Market data for a token
+ * Contains price, value, and 24h change information
+ */
+export type MarketData = {
+  __typename?: "MarketData";
+  id: string;
+  percentChange?: number | null;  // 24h percentage change
+  price?: number | null;           // Current price in USD
+  value?: number | null;           // Total value in USD (amount * price)
+  valueChange?: number | null;     // 24h value change in USD
+};
+
+/**
+ * Token balance information
+ * Represents a single token in the wallet
+ */
+export type TokenBalance = {
+  __typename?: "TokenBalance";
+  id: string;
+  address: string;              // Token mint address
+  amount: string;               // Raw amount (with decimals)
+  decimals: number;             // Number of decimal places
+  displayAmount: string;        // Formatted amount for display
+  marketData?: MarketData | null;
+  token: string;                // Token account address
+  tokenListEntry?: TokenListEntry | null;
+};
+
+/**
+ * Edge wrapper for token balance in connection
+ */
+export type TokenBalanceEdge = {
+  __typename?: "TokenBalanceEdge";
+  node: TokenBalance;
+};
+
+/**
+ * Connection type for paginated token balances
+ */
+export type TokenBalanceConnection = {
+  __typename?: "TokenBalanceConnection";
+  edges: TokenBalanceEdge[];
+};
+
+/**
+ * Aggregate balance information
+ * Total portfolio value and 24h change
+ */
+export type BalanceAggregate = {
+  __typename?: "BalanceAggregate";
+  id: string;
+  percentChange?: number | null;  // 24h percentage change for entire portfolio
+  value: number;                  // Total portfolio value in USD
+  valueChange?: number | null;    // 24h value change in USD for entire portfolio
+};
+
+/**
+ * Wallet balances container
+ * Contains both aggregate and individual token balances
+ */
+export type Balances = {
+  __typename?: "Balances";
+  id: string;
+  aggregate?: BalanceAggregate | null;
+  tokens?: TokenBalanceConnection | null;
+};
+
+/**
+ * Wallet type
+ * Top-level container for wallet data
+ */
+export type Wallet = {
+  __typename?: "Wallet";
+  id: string;
+  balances?: Balances | null;
+};
+
+/**
+ * GetTokenBalances query response
+ * Main query response for fetching token balances
+ */
+export type GetTokenBalancesQuery = {
+  __typename?: "Query";
+  wallet?: Wallet | null;
+};
+
+/**
+ * Response type for balance summary (aggregate data)
+ * Used for displaying total portfolio value
+ */
+export type ResponseBalanceSummary = BalanceAggregate;
+
+/**
+ * Response type for individual token balance
+ * Used for displaying token list rows
+ */
+export type ResponseTokenBalance = TokenBalance;

--- a/android/components/BalanceSummary.tsx
+++ b/android/components/BalanceSummary.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+export type BalanceSummaryProps = {
+  value: number;
+  percentChange: number;
+  valueChange: number;
+};
+
+/**
+ * Formats a number as USD currency
+ * @param value - The number to format
+ * @returns Formatted currency string (e.g., "$1,234.56")
+ */
+function formatUSD(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+/**
+ * Formats a percentage change
+ * @param percentChange - The percentage to format
+ * @returns Formatted percentage string (e.g., "+5.23%", "-2.15%")
+ */
+function formatPercentChange(percentChange: number): string {
+  const sign = percentChange >= 0 ? "+" : "";
+  return `${sign}${percentChange.toFixed(2)}%`;
+}
+
+/**
+ * BalanceSummary Component
+ * Displays the total portfolio value and 24h change
+ *
+ * Features:
+ * - Shows total USD value
+ * - Displays 24h percentage change
+ * - Displays 24h value change
+ * - Color-coded indicators (green for positive, red for negative)
+ */
+export const BalanceSummary = ({
+  value,
+  percentChange,
+  valueChange,
+}: BalanceSummaryProps) => {
+  const isPositive = percentChange >= 0;
+  const changeColor = isPositive ? "#00C853" : "#FF3B30"; // Green or Red
+
+  return (
+    <View style={styles.container}>
+      {/* Total Portfolio Value */}
+      <Text style={styles.totalValue}>{formatUSD(value)}</Text>
+
+      {/* 24h Change */}
+      <View style={styles.changeContainer}>
+        <Text style={[styles.changeText, { color: changeColor }]}>
+          {formatPercentChange(percentChange)}
+        </Text>
+        <Text style={[styles.changeText, { color: changeColor }]}>
+          {" "}
+          ({formatUSD(Math.abs(valueChange))})
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    paddingVertical: 20,
+    width: "100%",
+  },
+  totalValue: {
+    fontSize: 36,
+    fontWeight: "bold",
+    color: "#000",
+    marginBottom: 8,
+  },
+  changeContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  changeText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  label: {
+    fontSize: 12,
+    color: "#8E8E93",
+    marginTop: 4,
+  },
+});

--- a/android/components/BalancesTable.tsx
+++ b/android/components/BalancesTable.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import type { ResponseTokenBalance } from "../apollo/types";
+import { BalancesTableRow } from "./BalancesTableRow";
+
+export type BalancesTableProps = {
+  balances: ResponseTokenBalance[];
+  onItemClick?: (args: {
+    id: string;
+    displayAmount: string;
+    symbol: string;
+    token: string;
+    tokenAccount: string;
+  }) => void | Promise<void>;
+};
+
+/**
+ * BalancesTable Component
+ * Displays a scrollable list of token balances
+ *
+ * Features:
+ * - FlatList for efficient rendering
+ * - Shows each token with logo, name, balance, and market data
+ * - Supports item click handlers
+ * - Empty state when no tokens
+ */
+export const BalancesTable = ({
+  balances,
+  onItemClick,
+}: BalancesTableProps) => {
+  // Handle empty state
+  if (!balances || balances.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyText}>No tokens found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.list}>
+      {balances.map((item) => (
+        <BalancesTableRow
+          key={item.id}
+          balance={item}
+          onPress={
+            onItemClick
+              ? () =>
+                  onItemClick({
+                    id: item.id,
+                    displayAmount: item.displayAmount,
+                    symbol: item.tokenListEntry?.symbol ?? "Unknown",
+                    token: item.address,
+                    tokenAccount: item.token,
+                  })
+              : undefined
+          }
+        />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  list: {
+    width: "100%",
+  },
+  listContent: {
+    paddingBottom: 20,
+  },
+  emptyContainer: {
+    padding: 40,
+    alignItems: "center",
+  },
+  emptyText: {
+    fontSize: 16,
+    color: "#8E8E93",
+  },
+});

--- a/android/components/BalancesTableRow.tsx
+++ b/android/components/BalancesTableRow.tsx
@@ -1,0 +1,194 @@
+import React from "react";
+import {
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  Platform,
+} from "react-native";
+import type { ResponseTokenBalance } from "../apollo/types";
+
+export type BalancesTableRowProps = {
+  balance: ResponseTokenBalance;
+  onPress?: () => void;
+};
+
+/**
+ * Formats a number as USD currency
+ */
+function formatUSD(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+/**
+ * Formats a display amount with proper decimals
+ */
+function formatDisplayAmount(amount: string, decimals: number): string {
+  const num = parseFloat(amount);
+  if (isNaN(num)) return "0";
+
+  // For small amounts, show more decimals
+  if (num < 0.01 && num > 0) {
+    return num.toFixed(Math.min(8, decimals));
+  }
+
+  // For normal amounts, show 2-4 decimals
+  return num.toFixed(Math.min(4, decimals));
+}
+
+/**
+ * BalancesTableRow Component
+ * Displays a single token balance row
+ *
+ * Features:
+ * - Token logo (with fallback)
+ * - Token symbol and name
+ * - Display amount with decimals
+ * - USD value
+ * - 24h percentage change (color-coded)
+ * - Touchable for navigation
+ */
+export const BalancesTableRow = ({
+  balance,
+  onPress,
+}: BalancesTableRowProps) => {
+  const {
+    tokenListEntry,
+    displayAmount,
+    decimals,
+    marketData,
+  } = balance;
+
+  const symbol = tokenListEntry?.symbol ?? "Unknown";
+  const name = tokenListEntry?.name ?? "Unknown Token";
+  const logo = tokenListEntry?.logo;
+  const price = marketData?.price ?? 0;
+  const value = marketData?.value ?? 0;
+  const percentChange = marketData?.percentChange ?? 0;
+
+  const isPositive = percentChange >= 0;
+  const changeColor = isPositive ? "#00C853" : "#FF3B30"; // Green or Red
+
+  const Container = onPress ? TouchableOpacity : View;
+
+  return (
+    <Container
+      style={styles.row}
+      onPress={onPress}
+      activeOpacity={onPress ? 0.7 : 1}
+    >
+      {/* Token Logo */}
+      <View style={styles.logoContainer}>
+        {logo ? (
+          <Image source={{ uri: logo }} style={styles.logo} />
+        ) : (
+          <View style={styles.logoPlaceholder}>
+            <Text style={styles.logoPlaceholderText}>
+              {symbol.charAt(0)}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* Token Info */}
+      <View style={styles.infoContainer}>
+        <Text style={styles.symbol}>{symbol}</Text>
+        <Text style={styles.name} numberOfLines={1}>
+          {name}
+        </Text>
+      </View>
+
+      {/* Balance and Value */}
+      <View style={styles.valueContainer}>
+        <Text style={styles.balance}>
+          {formatDisplayAmount(displayAmount, decimals)}
+        </Text>
+        <View style={styles.priceRow}>
+          <Text style={styles.usdValue}>{formatUSD(value)}</Text>
+          {percentChange !== 0 && (
+            <Text style={[styles.percentChange, { color: changeColor }]}>
+              {" "}
+              {isPositive ? "↗" : "↘"} {isPositive ? "+" : ""}
+              {percentChange.toFixed(2)}%
+            </Text>
+          )}
+        </View>
+      </View>
+    </Container>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: "transparent",
+    borderBottomWidth: 1,
+    borderBottomColor: "#2a2a2a",
+  },
+  logoContainer: {
+    marginRight: 12,
+  },
+  logo: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#F2F2F7",
+  },
+  logoPlaceholder: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#007AFF",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  logoPlaceholderText: {
+    color: "#FFF",
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  infoContainer: {
+    flex: 1,
+    marginRight: 12,
+  },
+  symbol: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
+    marginBottom: 2,
+  },
+  name: {
+    fontSize: 13,
+    color: "#8E8E93",
+  },
+  valueContainer: {
+    alignItems: "flex-end",
+  },
+  balance: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
+    marginBottom: 2,
+  },
+  priceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  usdValue: {
+    fontSize: 13,
+    color: "#8E8E93",
+  },
+  percentChange: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+});

--- a/android/components/TokenBalances.tsx
+++ b/android/components/TokenBalances.tsx
@@ -1,0 +1,127 @@
+import React, { Suspense, useMemo, useEffect } from "react";
+import { View, ActivityIndicator } from "react-native";
+import { GET_TOKEN_BALANCES_QUERY } from "../apollo/queries";
+import type {
+  ProviderId,
+  ResponseBalanceSummary,
+  ResponseTokenBalance,
+} from "../apollo/types";
+import { usePolledSuspenseQuery } from "../hooks/usePolledSuspenseQuery";
+import { BalancesTable } from "./BalancesTable";
+
+// Default polling interval: 60 seconds
+const DEFAULT_POLLING_INTERVAL_SECONDS = 60;
+
+export type TokenBalancesProps = {
+  address: string;
+  providerId: ProviderId;
+  pollingIntervalSeconds?: number;
+  onBalanceUpdate?: (balanceUSD: string) => void;
+  onItemClick?: (args: {
+    id: string;
+    displayAmount: string;
+    symbol: string;
+    token: string;
+    tokenAccount: string;
+  }) => void | Promise<void>;
+};
+
+/**
+ * TokenBalances component with Suspense wrapper
+ * Displays loading state while data is being fetched
+ */
+export const TokenBalances = ({
+  address,
+  providerId,
+  pollingIntervalSeconds,
+  onBalanceUpdate,
+  onItemClick,
+}: TokenBalancesProps) => {
+  return (
+    <Suspense
+      fallback={
+        <View style={{ flex: 1, justifyContent: "center", alignItems: "center", padding: 20 }}>
+          <ActivityIndicator size="large" color="#007AFF" />
+        </View>
+      }
+    >
+      <_TokenBalances
+        address={address}
+        providerId={providerId}
+        pollingIntervalSeconds={pollingIntervalSeconds}
+        onBalanceUpdate={onBalanceUpdate}
+        onItemClick={onItemClick}
+      />
+    </Suspense>
+  );
+};
+
+/**
+ * Internal TokenBalances component
+ * Fetches and displays token balances with market data
+ */
+function _TokenBalances({
+  address,
+  providerId,
+  pollingIntervalSeconds,
+  onBalanceUpdate,
+  onItemClick,
+}: TokenBalancesProps) {
+  // Normalize providerId to remove network suffix for Backpack API
+  // Backpack GraphQL API only accepts "SOLANA" (not "SOLANA-mainnet" etc.)
+  const normalizedProviderId = providerId.startsWith("SOLANA")
+    ? "SOLANA"
+    : providerId;
+
+  // Fetch token balances with polling
+  const { data, error } = usePolledSuspenseQuery(
+    pollingIntervalSeconds ?? DEFAULT_POLLING_INTERVAL_SECONDS,
+    GET_TOKEN_BALANCES_QUERY,
+    {
+      errorPolicy: "all",
+      variables: {
+        address,
+        providerId: normalizedProviderId as ProviderId,
+      },
+    }
+  );
+
+  // Extract token balances from GraphQL response
+  const balances: ResponseTokenBalance[] = useMemo(() => {
+    return data?.wallet?.balances?.tokens?.edges.map((e) => e.node) ?? [];
+  }, [data]);
+
+  // Extract aggregate balance summary from GraphQL response
+  const aggregate: ResponseBalanceSummary = useMemo(() => {
+    return (
+      data?.wallet?.balances?.aggregate ?? {
+        id: "",
+        percentChange: 0,
+        value: 0,
+        valueChange: 0,
+      }
+    );
+  }, [data]);
+
+  // Call callback when aggregate balance changes
+  useEffect(() => {
+    if (onBalanceUpdate && aggregate.value !== undefined) {
+      const formattedBalance = `$${aggregate.value.toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`;
+      onBalanceUpdate(formattedBalance);
+    }
+  }, [aggregate.value, onBalanceUpdate]);
+
+  // Log error if present (for debugging)
+  if (error) {
+    console.error("Error fetching token balances:", error);
+  }
+
+  return (
+    <View style={{ flex: 1, alignItems: "center", padding: 16 }}>
+      <BalancesTable balances={balances} onItemClick={onItemClick} />
+    </View>
+  );
+}

--- a/android/hooks/usePolledSuspenseQuery.ts
+++ b/android/hooks/usePolledSuspenseQuery.ts
@@ -1,0 +1,73 @@
+import {
+  type OperationVariables,
+  type SuspenseQueryHookOptions,
+  useSuspenseQuery,
+} from "@apollo/client";
+import { startTransition, useEffect } from "react";
+
+/**
+ * Wrapper hook around the Apollo client `useSuspenseQuery` to add intervalled
+ * polling of new data based on the argued interval length in seconds.
+ *
+ * Features:
+ * - Automatically refetches data at the specified interval
+ * - Supports Suspense for loading states
+ * - Can be disabled by passing "disabled" as interval
+ * - Uses React's startTransition for non-blocking updates
+ *
+ * @template TData - The type of data returned by the query
+ * @template TVariables - The type of variables passed to the query
+ * @template TOptions - Additional options for the query
+ * @param {number | "disabled"} intervalSeconds - Polling interval in seconds, or "disabled" to disable polling
+ * @param {...Parameters<typeof useSuspenseQuery>} args - Arguments passed to useSuspenseQuery
+ * @returns Query result with data, loading state, error, and refetch function
+ *
+ * @example
+ * ```typescript
+ * const { data, error, refetch } = usePolledSuspenseQuery(
+ *   60, // Poll every 60 seconds
+ *   GET_TOKEN_BALANCES_QUERY,
+ *   {
+ *     variables: { address: "...", providerId: "SOLANA" }
+ *   }
+ * );
+ * ```
+ */
+export function usePolledSuspenseQuery<
+  TData,
+  TVariables extends OperationVariables,
+  TOptions extends Omit<
+    SuspenseQueryHookOptions<TData, OperationVariables>,
+    "variables"
+  >,
+>(
+  intervalSeconds: number | "disabled",
+  ...args: Parameters<typeof useSuspenseQuery<TData, TVariables, TOptions>>
+): ReturnType<
+  typeof useSuspenseQuery<TData | undefined, TVariables, TOptions>
+> {
+  const res = useSuspenseQuery(...args);
+
+  useEffect(() => {
+    if (intervalSeconds === "disabled" || intervalSeconds <= 0) {
+      return () => {};
+    }
+
+    const id = setInterval(() => {
+      // Use startTransition if available for non-blocking updates
+      if (typeof startTransition === "function") {
+        startTransition(() => {
+          res.refetch();
+        });
+      } else {
+        res.refetch();
+      }
+    }, intervalSeconds * 1000);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [intervalSeconds, res]);
+
+  return res;
+}

--- a/android/package-lock.json
+++ b/android/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@apollo/client": "^3.14.0",
         "@craftzdog/react-native-buffer": "^6.1.1",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@ledgerhq/hw-app-solana": "^7.6.0",
@@ -17,6 +18,8 @@
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.4.1",
         "@solana/web3.js": "^1.98.4",
+        "@types/react": "~19.1.10",
+        "apollo3-cache-persist": "^0.14.1",
         "bip39": "^3.1.0",
         "bs58": "^6.0.0",
         "buffer": "^6.0.3",
@@ -26,6 +29,7 @@
         "expo-clipboard": "~8.0.7",
         "expo-secure-store": "~15.0.7",
         "expo-status-bar": "~3.0.8",
+        "graphql": "^16.12.0",
         "micro-key-producer": "^0.8.2",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -37,7 +41,8 @@
         "react-native-webview": "^13.16.0",
         "react-native-worklets": "^0.6.1",
         "stream-browserify": "^3.0.0",
-        "tweetnacl": "^1.0.3"
+        "tweetnacl": "^1.0.3",
+        "typescript": "~5.9.2"
       },
       "devDependencies": {
         "patch-package": "^8.0.1"
@@ -53,6 +58,48 @@
       },
       "peerDependenciesMeta": {
         "graphql": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.14.0.tgz",
+      "integrity": "sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
           "optional": true
         }
       }
@@ -80,7 +127,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2501,6 +2547,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3567,6 +3622,15 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3630,6 +3694,54 @@
       },
       "peerDependencies": {
         "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3777,6 +3889,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apollo3-cache-persist": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.14.1.tgz",
+      "integrity": "sha512-p/jNzN/MmSd0TmY7/ts0B3qi0SdQ3w9yNLQdKqB3GGb9xATUlAum2v4hSrTeWd/DZKK2Z7Xg5kFXTH6nNVnKSQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@apollo/client": "^3.2.5"
       }
     },
     "node_modules/arg": {
@@ -4371,7 +4492,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5037,6 +5157,12 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.0.tgz",
+      "integrity": "sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5508,7 +5634,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.23.tgz",
       "integrity": "sha512-b4uQoiRwQ6nwqsT2709RS15CWYNGF3eJtyr1KyLw9WuMAK7u4jjofkhRiO0+3o1C2NbV+WooyYTOZGubQQMBaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.16",
@@ -6025,7 +6150,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.9.tgz",
       "integrity": "sha512-xCoQbR/36qqB6tew/LQ6GWICpaBmHLhg/Loix5Rku/0ZtNaXMJv08M9o1AcrdiGTn/Xf/BnLu6DgS45cWQEHZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6493,6 +6617,30 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -8716,6 +8864,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/ora": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
@@ -9500,7 +9660,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9526,7 +9685,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -9584,7 +9742,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -9651,7 +9808,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.3.tgz",
       "integrity": "sha512-GP8wsi1u3nqvC1fMab/m8gfFwFyldawElCcUSBJQgfrXeLmsPPUOpDw44lbLeCpcwUuLa05WTVePdTEwCLTUZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -9680,7 +9836,6 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -9696,7 +9851,6 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
       "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -9723,7 +9877,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.6.1.tgz",
       "integrity": "sha512-URca8l7c7Uog7gv4mcg9KILdJlnbvwdS5yfXQYf5TDkD2W1VY1sduEKrD+sA3lUPXH/TG1vmXAvNxCNwPMYgGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -9844,7 +9997,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9927,6 +10079,24 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/require-directory": {
@@ -10831,6 +11001,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
@@ -11070,6 +11249,18 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -11119,7 +11310,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11575,7 +11765,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -11734,12 +11923,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "zen-observable": "0.8.15"
+      }
+    },
     "node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/android/package.json
+++ b/android/package.json
@@ -10,6 +10,7 @@
     "postinstall": "sed -i 's/safePromise\\.reject(null, errorConverter\\.toJs(error))/safePromise.reject(error.errorCode.name(), errorConverter.toJs(error))/g' node_modules/@ledgerhq/react-native-hw-transport-ble/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/BlePlxModule.java 2>/dev/null || true; sed -i 's/promise\\.reject(code, message)/promise.reject(code == null ? \"UNKNOWN_ERROR\" : code, message)/g' node_modules/@ledgerhq/react-native-hw-transport-ble/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java 2>/dev/null || true; sed -i 's/promise\\.reject(code, e)/promise.reject(code == null ? \"UNKNOWN_ERROR\" : code, e)/g' node_modules/@ledgerhq/react-native-hw-transport-ble/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java 2>/dev/null || true; sed -i 's/promise\\.reject(code, message, e)/promise.reject(code == null ? \"UNKNOWN_ERROR\" : code, message, e)/g' node_modules/@ledgerhq/react-native-hw-transport-ble/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java 2>/dev/null || true"
   },
   "dependencies": {
+    "@apollo/client": "^3.14.0",
     "@craftzdog/react-native-buffer": "^6.1.1",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@ledgerhq/hw-app-solana": "^7.6.0",
@@ -18,6 +19,8 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@solana/web3.js": "^1.98.4",
+    "@types/react": "~19.1.10",
+    "apollo3-cache-persist": "^0.14.1",
     "bip39": "^3.1.0",
     "bs58": "^6.0.0",
     "buffer": "^6.0.3",
@@ -27,6 +30,7 @@
     "expo-clipboard": "~8.0.7",
     "expo-secure-store": "~15.0.7",
     "expo-status-bar": "~3.0.8",
+    "graphql": "^16.12.0",
     "micro-key-producer": "^0.8.2",
     "react": "19.1.0",
     "react-native": "0.81.5",
@@ -38,7 +42,8 @@
     "react-native-webview": "^13.16.0",
     "react-native-worklets": "^0.6.1",
     "stream-browserify": "^3.0.0",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "typescript": "~5.9.2"
   },
   "private": true,
   "devDependencies": {

--- a/android/tsconfig.json
+++ b/android/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}

--- a/android/yarn.lock
+++ b/android/yarn.lock
@@ -7,6 +7,25 @@
   resolved "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz"
   integrity sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==
 
+"@apollo/client@^3.14.0", "@apollo/client@^3.2.5":
+  version "3.14.0"
+  resolved "https://registry.npmjs.org/@apollo/client/-/client-3.14.0.tgz"
+  integrity sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/caches" "^1.0.0"
+    "@wry/equality" "^0.5.6"
+    "@wry/trie" "^0.5.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.18.0"
+    prop-types "^15.7.2"
+    rehackt "^0.1.0"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@babel/code-frame@^7.12.13":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz"
@@ -1166,6 +1185,11 @@
   dependencies:
     nanoid "^3.3.1"
 
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
@@ -1735,6 +1759,13 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
+"@types/react@*", "@types/react@^19.1.0", "@types/react@~19.1.10":
+  version "19.1.17"
+  resolved "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz"
+  integrity sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==
+  dependencies:
+    csstype "^3.0.2"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
@@ -1791,6 +1822,34 @@
   dependencies:
     "@urql/core" "^5.1.2"
     wonka "^6.3.2"
+
+"@wry/caches@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz"
+  integrity sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/context@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz"
+  integrity sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.6":
+  version "0.5.7"
+  resolved "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz"
+  integrity sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz"
+  integrity sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==
+  dependencies:
+    tslib "^2.3.0"
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"
@@ -1897,6 +1956,11 @@ anymatch@^3.0.3:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+apollo3-cache-persist@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.14.1.tgz"
+  integrity sha512-p/jNzN/MmSd0TmY7/ts0B3qi0SdQ3w9yNLQdKqB3GGb9xATUlAum2v4hSrTeWd/DZKK2Z7Xg5kFXTH6nNVnKSQ==
 
 arg@^5.0.2:
   version "5.0.2"
@@ -2693,6 +2757,11 @@ css-what@^6.1.0:
   resolved "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz"
   integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
+csstype@^3.0.2:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.0.tgz"
+  integrity sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -3350,6 +3419,18 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4,
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
+"graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "graphql@^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "graphql@^14.0.0 || ^15.0.0 || ^16.0.0", "graphql@^15.0.0 || ^16.0.0", graphql@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz"
+  integrity sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
@@ -3452,7 +3533,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -4479,6 +4560,16 @@ open@^8.0.4:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+optimism@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz"
+  integrity sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==
+  dependencies:
+    "@wry/caches" "^1.0.0"
+    "@wry/context" "^0.7.0"
+    "@wry/trie" "^0.5.0"
+    tslib "^2.3.0"
+
 ora@^3.4.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz"
@@ -4709,7 +4800,7 @@ prompts@^2.3.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.0:
+prop-types@^15.7.2, prop-types@^15.8.0:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -4936,7 +5027,7 @@ react-refresh@^0.14.0, react-refresh@^0.14.2, "react-refresh@>=0.14.0 <1.0.0":
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
-react@*, react@^19.1.0, react@19.1.0:
+react@*, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc", react@^19.1.0, react@19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react/-/react-19.1.0.tgz"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
@@ -5003,6 +5094,11 @@ regjsparser@^0.13.0:
   integrity sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==
   dependencies:
     jsesc "~3.1.0"
+
+rehackt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz"
+  integrity sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -5510,6 +5606,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 tar@^7.4.3:
   version "7.5.2"
   resolved "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz"
@@ -5623,7 +5724,14 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-tslib@^2.1.0, tslib@^2.8.0:
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
+tslib@^2.1.0, tslib@^2.3.0, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -5657,7 +5765,7 @@ typed-array-buffer@^1.0.3:
     es-errors "^1.3.0"
     is-typed-array "^1.1.14"
 
-typescript@>=5.3.3:
+typescript@>=5.3.3, typescript@~5.9.2:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
@@ -6015,6 +6123,18 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zod-to-json-schema@^3.24.6:
   version "3.24.6"


### PR DESCRIPTION
## Summary
Implemented comprehensive UI enhancements and GraphQL integration for Solana token pricing with dark mode fixes and visual improvements.

## Changes

### GraphQL Integration
- ✅ Add Apollo Client setup with cache persistence
- ✅ Implement token balances query with market data (price, 24h change)
- ✅ Create polled suspense query hook for real-time updates
- ✅ Add TypeScript types for GraphQL responses

### UI Components
- ✅ **BalancesTable**: Displays token list with `map()` instead of `FlatList` (fixes nested VirtualizedLists warning)
- ✅ **BalancesTableRow**: Shows token info with logo, balance, and market data
- ✅ **BalanceSummary**: Displays total portfolio value and 24h change
- ✅ **TokenBalances**: Wrapper component with GraphQL data fetching

### Dark Mode Fixes
- ✅ Set transparent background for token rows (was white)
- ✅ Update text colors to white for dark theme
- ✅ Adjust border colors for better dark mode contrast

### Visual Enhancements
- ✅ Add trend arrows (↗↘) to 24h percentage changes
- ✅ Remove "24h change" label text for cleaner UI
- ✅ Unified layout: balance display at top for all chains (Solana and X1)

### Bug Fixes
- ✅ Fix Solana balance display (now shows GraphQL data instead of X1 balance)
- ✅ Add callback to sync GraphQL balance with top display
- ✅ Fix `activeNetwork` variable scope error
- ✅ Add null guards for network references

## Dependencies Added
- `@apollo/client` ^3.14.0
- `graphql` ^16.12.0
- `apollo3-cache-persist` ^0.14.1

## Test Plan
- [x] Build succeeds
- [x] App launches without errors
- [x] Solana tokens display with correct pricing
- [x] Dark mode tokens have transparent background and white text
- [x] Trend arrows show correctly for positive/negative changes
- [x] Balance at top shows correct Solana balance
- [x] No VirtualizedLists warning in console
- [x] Layout matches between X1 and Solana chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)